### PR TITLE
Add support for listing momentum spends

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ https://discordapp.com/api/oauth2/authorize?client_id=729181873024139294&permiss
 
 `!determination` - Determination spend table.
 
+`!momentum` - Momentum spend table.
+
 **Reference for ship characters**
 
 `!ship actions` - Lists the stations and the name of the actions that can be performed at that station.

--- a/app.js
+++ b/app.js
@@ -119,6 +119,9 @@ bot.on("message", async (message) => {
         case "determination":
           embed = msgBuilder.buildDeterminationMsg()
           break
+        case "momentum":
+          embed = msgBuilder.buildMomentumMsg()
+          break
         case "alien":
           embed = msgBuilder.buildGeneratedAlienMsg()
           break

--- a/data/help2.txt
+++ b/data/help2.txt
@@ -4,6 +4,7 @@
 `!pc [action or minor action]` - Details of a PC action or minor action by name. See `!pc actions` or `!pc minor actions`.
 `!pc attack properties` - Attack properties of a PC attack.
 `!determination` - Determination spend table.
+`!momentum` - Momentum spend table.
 **Reference for ship characters.**
 `!ship actions` - Lists the stations and the name of the actions that can be performed at that station.
 `!ship minor actions` - The minor actions the PC can perform.

--- a/data/momentum.json
+++ b/data/momentum.json
@@ -1,0 +1,6 @@
+{
+    "CREATE OPPORTUNITY": "Must be declared before a roll. Points of Momentum may be spent to grant the character up to 3 bonus d20. The first costs 1 Momentum, the second 2 Momentum, the third 3 Momentum. The normal limit of additional d20s bought for a Task still applies.",
+    "CREATE PROBLEM": "Must be declared before an opponent's roll. A character can increase the opposing character's Complication Range by 1 per 2 Momentum spent.",
+    "CREATE ADVANTAGE": "For 2 points of Momentum, the character immediately creates an Advantage that applies to the current scene, or removes a Complication that applies to the current scene.",
+    "OBTAIN INFORMATION": "For 1 point of Momentum per question, the character may ask the Gamemaster additional questions about the situation, which will be answered truthfully (but not necessarily exhaustively)."
+}

--- a/messageBuilder.js
+++ b/messageBuilder.js
@@ -237,6 +237,23 @@ module.exports = {
     console.warn(embed)
     return embed
   },
+  buildMomentumMsg() {
+    const embed = {
+      title: "MOMENTUM SPENDS",
+      fields: [],
+    }
+
+    const momentumSpends = referenceSheets.momentum
+    for (let key in momentumSpends) {
+      embed.fields.push({
+        name: key,
+        value: momentumSpends[key],
+      })
+    }
+
+    console.warn(embed)
+    return embed
+  },
   buildGeneratedAlienMsg() {
     const embed = {
       title: "GENERATED ALIEN",

--- a/referenceSheets.js
+++ b/referenceSheets.js
@@ -57,6 +57,9 @@ module.exports = {
     this.determination = JSON.parse(
       fs.readFileSync("./data/determination.json", { encoding: "utf8" })
     )
+    this.momentum = JSON.parse(
+      fs.readFileSync("./data/momentum.json", { encoding: "utf8" })
+    )
 
     this.shipMinorActions = JSON.parse(
       fs.readFileSync("./data/shipMinorActions.json", { encoding: "utf8" })


### PR DESCRIPTION
This adds support for using `!momentum` in the same manner as `!determination`, to get a list of common momentum spends.
Essentially, I copied the existing mechanism for `!determination`.

Many thanks for this project!