### PR TITLE
add `!about` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Support this project: https://www.patreon.com/majeldiscordbot
 
 `!addme` - Invite me to your game!
 
+`!about` - Information on development and source code.
+
 ![d6 Rolls](https://i.imgur.com/DOaORZP.png "d6 Rolls")
 
 `!d6` - Roll a challenge die.

--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@ referenceSheets.loadReferenceSheets()
 // help content
 let help1 = fs.readFileSync("./data/help1.txt", { encoding: "utf8" })
 let help2 = fs.readFileSync("./data/help2.txt", { encoding: "utf8" })
+let about = fs.readFileSync("./data/about.txt", { encoding: "utf8" })
 
 let addMeMsg =
   "https://discordapp.com/api/oauth2/authorize?client_id=538555398521618432&permissions=51200&scope=bot"
@@ -101,6 +102,9 @@ bot.on("message", async (message) => {
         case "help":
           message.channel.send(help1)
           message.channel.send(help2)
+          return
+        case "about":
+          message.channel.send(about)
           return
         case "support":
           if (option.includes("list")) {

--- a/data/about.txt
+++ b/data/about.txt
@@ -1,0 +1,3 @@
+The source code and full documentation of this bot can be found at https://github.com/engooyen/majel. 
+
+If you find the project helpful, consider supporting it or spreading the word on social media! You can find all the necessary information at the above link.

--- a/data/help1.txt
+++ b/data/help1.txt
@@ -1,6 +1,7 @@
 **MAJEL - STAR TREK ADVENTURES BOT COMMAND LIST**
 `!help` - Displays all possible commands Majel can understand.
 `!addme` - Invite me to your game!
+`!about` - Information on development and source code.
 `!d6` - Roll a challenge die.
 `!Xd6` - Roll X challenge dice (e.g. Roll 5 d6 = !5d6). X can be left blank, defaults to 1.
 `!d20` - Roll a d20.


### PR DESCRIPTION
It took me quite a time to find this repo after using Majel for days.
This adds a `!about` command which links to this repo and documents the existence of the command.

Feel free to change the message.

I hope the additional lines in help1.txt don't break anything - I don't really have the environment to test the changes :/