### PR TITLE
Extending output by source book information

### DIFF
--- a/app.js
+++ b/app.js
@@ -109,6 +109,8 @@ bot.on("message", async (message) => {
         case "support":
           if (option.includes("list")) {
             msg = "Supported species: " + utils.listSpecies()
+            msg += "\n"
+            msg += "Supported sources: " + utils.listSpeciesSources()
           } else {
             embed = utils.generateSupportCharacter()
           }

--- a/data/species.json
+++ b/data/species.json
@@ -9,7 +9,8 @@
             "Control": 1,
             "Presence": 1
         },
-        "Talents": ["PROUD AND HONORABLE", "THE USHAAN"]
+        "Talents": ["PROUD AND HONORABLE", "THE USHAAN"],
+        "Source": "core"
     },
     {
         "Name": "Bajoran",
@@ -21,7 +22,8 @@
             "Daring": 1,
             "Insight": 1
         },
-        "Talents": ["ORB EXPERIENCE", "STRONG PAGH"]
+        "Talents": ["ORB EXPERIENCE", "STRONG PAGH"],
+        "Source": "core"
     },
     {
         "Name": "Betazoid",
@@ -33,7 +35,8 @@
             "Presence": 1,
             "Reason": 1
         },
-        "Talents": ["EMPATH", "TELEPATH"]
+        "Talents": ["EMPATH", "TELEPATH"],
+        "Source": "core"
     },
     {
         "Name": "Denobulan",
@@ -45,7 +48,8 @@
             "Insight": 1,
             "Reason": 1
         },
-        "Talents": ["CULTURAL FLEXIBILITY", "PARENT FIGURE"]
+        "Talents": ["CULTURAL FLEXIBILITY", "PARENT FIGURE"],
+        "Source": "core"
     },
     {
         "Name": "Human",
@@ -57,7 +61,8 @@
             "Insight": 1,
             "Reason": 1
         },
-        "Talents": ["RESOLUTE", "SPIRIT OF DISCOVERY"]
+        "Talents": ["RESOLUTE", "SPIRIT OF DISCOVERY"],
+        "Source": "core"
     },
     {
         "Name": "Tellarite",
@@ -69,7 +74,8 @@
             "Fitness": 1,
             "Insight": 1
         },
-        "Talents": ["INCISIVE SCRUTINY", "STURDY"]
+        "Talents": ["INCISIVE SCRUTINY", "STURDY"],
+        "Source": "core"
     },
     {
         "Name": "Trill",
@@ -81,7 +87,8 @@
             "Presence": 1,
             "Reason": 1
         },
-        "Talents": ["FORMER INITATE", "JOINED"]
+        "Talents": ["FORMER INITATE", "JOINED"],
+        "Source": "core"
     },
     {
         "Name": "Vulcan",
@@ -93,6 +100,7 @@
             "Fitness": 1,
             "Reason": 1
         },
-        "Talents": ["KOLINAHR", "MIND-MELD", "NERVE PINCH"]
+        "Talents": ["KOLINAHR", "MIND-MELD", "NERVE PINCH"],
+        "Source": "core"
     }
 ]

--- a/utils.js
+++ b/utils.js
@@ -121,13 +121,17 @@ module.exports = {
 
     let talent = this.shuffle(race.Talents)[0]
 
+    if (race.Source === undefined) {
+      console.warn("Source book for " + race.Name + " is undefined")
+    }
+
     return {
       title: firstName + " " + lastName,
       description: "Generated support character",
       fields: [
         {
           name: "Race",
-          value: race.Name,
+          value: race.Name + " (" + race.Source + " source book)",
         },
         {
           name: "Gender",

--- a/utils.js
+++ b/utils.js
@@ -53,6 +53,16 @@ module.exports = {
   },
 
   /**
+   * Lists supported source books for species
+   * @return Returns a list of supported sources
+   */
+  listSpeciesSources() {
+    // remove duplicates by casting to Set and back
+    const list = [...new Set(species.map(s => s.Source))]
+    list.sort()
+    return list.join(", ")
+  },
+  /**
    * Finds the attribute in a map and returns the modifier value. If the
    * attribute doesn't exist, 0 is returned.
    * @param name The name of the attribute.


### PR DESCRIPTION
This adds a "Source" field to the structure in data/species.json, thereby closing #23, and outputs a list of all possible source books as part of `!support list`, thereby closing #22. I have decided against implementing it as a separate parameter for `!support list`.

I have also decided against implementing Source as an array of strings, because it is easier to take care of species using multiple source books by using multiple entries in the species file.

Also, the source book is now output as part of the species, because if you want to look up a particular species, you would want to know which source book to check.