### PR TITLE
fix #44. 20 not success when target unspecified

### DIFF
--- a/dice.js
+++ b/dice.js
@@ -61,7 +61,7 @@ module.exports = {
     let rawResult = ""
     let critRange = 1
     let compRange = this.globalComplication
-    let target = 20
+    let target = compRange - 1 // everything under a complication can be a success
     let success = 0
     let complication = 0
 


### PR DESCRIPTION
When no target number is specified, a 20 was incorrectly counted as a success, because (roll result) 20 <= (default target) 20. This fixes the default target to be below the complication range.